### PR TITLE
ChromaticにStorybookをデプロイするWorkflowを追加

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -19,3 +19,4 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          onlyChanged: true

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,0 +1,21 @@
+name: chromatic
+
+on: push
+
+jobs:
+  chromatic-deployment:
+    name: Deploy Storybook to chromatic
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Install dependencies
+        run: npm ci --legacy-peer-deps
+      - name: Publish to Chromatic
+        uses: chromaui/action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ai-cat-frontend
 
+[![chromatic](https://github.com/nekochans/ai-cat-frontend/actions/workflows/chromatic.yml/badge.svg)](https://github.com/nekochans/ai-cat-frontend/actions/workflows/chromatic.yml)
+
 ねこの人格を持った AI とお話できるサービスの Web フロントエンド
 
 ## 以下は `npx create-next-app@latest` が生成した結果をマージしたもの


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/ai-cat-frontend/issues/3

# この PR で対応する範囲 / この PR で対応しない範囲

ChromaticにStorybookをデプロイする為のWorkflowを追加する。

# Storybook の URL、 スクリーンショット

https://647ee6f3dfc9fdebe0ceca01-vqknpjuhjj.chromatic.com/?path=/story/app-components-footer--default

# 変更点概要

以下を参考にStorybookをchromaticにデプロイする為のWorkflowを追加。

https://www.chromatic.com/docs/github-actions

ビジュアルリグレッションテスト用のスナップショットは無料プランだと月に5000回なので少しでも節約する為に `onlyChanged: true` を追加。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

特になし