### PR TITLE
CI用のWorkflowを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    name: Build And Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 7
+    strategy:
+      matrix:
+        node-version: [18.x]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+      - run: |
+          npm ci --legacy-peer-deps
+          npm run lint
+          npm test

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # ai-cat-frontend
 
+[![ci](https://github.com/nekochans/ai-cat-frontend/actions/workflows/ci.yml/badge.svg)](https://github.com/nekochans/ai-cat-frontend/actions/workflows/ci.yml)
 [![chromatic](https://github.com/nekochans/ai-cat-frontend/actions/workflows/chromatic.yml/badge.svg)](https://github.com/nekochans/ai-cat-frontend/actions/workflows/chromatic.yml)
 
 ねこの人格を持った AI とお話できるサービスの Web フロントエンド


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/ai-cat-frontend/issues/24

# この PR で対応する範囲 / この PR で対応しない範囲

PR作成時にLinter, Testの実行が出来るようにする。

コードカバレッジの計測・閲覧に関しては別PRで対応する。

# Storybook の URL、 スクリーンショット

UI変更はないのでなし。

# 変更点概要

CI用のWorkflowを追加。実行しているのはLinterとTestだけ。

他にもアプリケーションのBuildやStorybookのBuildを行う手もあるが、それは別のWorkflowでカバー出来るのでCIの中では実行しない事にした。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

特になし