### PR TITLE
コードカバレッジ確認の為に Codecov にカバレッジレポートを送信する設定を追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,4 +26,8 @@ jobs:
       - run: |
           npm ci --legacy-peer-deps
           npm run lint
-          npm test
+          npm run test:ci
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # ai-cat-frontend
 
 [![ci](https://github.com/nekochans/ai-cat-frontend/actions/workflows/ci.yml/badge.svg)](https://github.com/nekochans/ai-cat-frontend/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/nekochans/ai-cat-frontend/branch/main/graph/badge.svg?token=FDxy2OqaIf)](https://codecov.io/gh/nekochans/ai-cat-frontend)
 [![chromatic](https://github.com/nekochans/ai-cat-frontend/actions/workflows/chromatic.yml/badge.svg)](https://github.com/nekochans/ai-cat-frontend/actions/workflows/chromatic.yml)
 
 ねこの人格を持った AI とお話できるサービスの Web フロントエンド

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "test": "jest",
+    "test:ci": "jest --collect-coverage",
     "dev": "next dev",
     "build": "next build",
     "start": "next start",


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/ai-cat-frontend/issues/24

# この PR で対応する範囲 / この PR で対応しない範囲

テストコードのカバレッジレポートが送信されるようにする。

# Storybook の URL、 スクリーンショット

UI変更はないのでなし

# 変更点概要

コードカバレッジ確認の為に Codecov にカバレッジレポートを送信するように変更

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

特になし