### PR TITLE
バックエンドのAPIを正式版である ai-cat-api に変更

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "react-dom": "18.2.0",
         "tailwindcss": "3.3.2",
         "typescript": "5.0.4",
+        "uuid": "^9.0.0",
         "zod": "^3.21.4"
       },
       "devDependencies": {
@@ -37,6 +38,7 @@
         "@storybook/testing-library": "^0.1.0",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^14.0.0",
+        "@types/uuid": "^9.0.2",
         "@typescript-eslint/eslint-plugin": "^5.59.8",
         "chromatic": "^6.18.0",
         "eslint-config-prettier": "^8.8.0",
@@ -6943,6 +6945,12 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
       "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==",
+      "dev": true
+    },
+    "node_modules/@types/uuid": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.2.tgz",
+      "integrity": "sha512-kNnC1GFBLuhImSnV7w4njQkUiJi0ZXUycu1rUaouPqiKlXkh77JKgdRnTAp1x5eBwcIwbtI+3otwzuIDEuDoxQ==",
       "dev": true
     },
     "node_modules/@types/webpack-env": {
@@ -20799,7 +20807,6 @@
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
       "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
-      "dev": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -26325,6 +26332,12 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
       "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==",
+      "dev": true
+    },
+    "@types/uuid": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.2.tgz",
+      "integrity": "sha512-kNnC1GFBLuhImSnV7w4njQkUiJi0ZXUycu1rUaouPqiKlXkh77JKgdRnTAp1x5eBwcIwbtI+3otwzuIDEuDoxQ==",
       "dev": true
     },
     "@types/webpack-env": {
@@ -36733,8 +36746,7 @@
     "uuid": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
-      "dev": true
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
     },
     "v8-to-istanbul": {
       "version": "9.1.0",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "react-dom": "18.2.0",
     "tailwindcss": "3.3.2",
     "typescript": "5.0.4",
+    "uuid": "^9.0.0",
     "zod": "^3.21.4"
   },
   "devDependencies": {
@@ -49,6 +50,7 @@
     "@storybook/testing-library": "^0.1.0",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^14.0.0",
+    "@types/uuid": "^9.0.2",
     "@typescript-eslint/eslint-plugin": "^5.59.8",
     "chromatic": "^6.18.0",
     "eslint-config-prettier": "^8.8.0",

--- a/src/api/client/__tests__/fetchCatMessage.spec.ts
+++ b/src/api/client/__tests__/fetchCatMessage.spec.ts
@@ -27,6 +27,7 @@ describe('src/api/client/fetchCatMessage.ts fetchCatMessage TestCases', () => {
   it('should be able to fetch a CatMessage', async () => {
     const fetchedResponse = await fetchCatMessage({
       catName: 'moko',
+      userId: 'userId1234567890',
       message: 'こんにちは！',
     });
 
@@ -45,6 +46,7 @@ describe('src/api/client/fetchCatMessage.ts fetchCatMessage TestCases', () => {
 
     const dto = {
       catName: 'moko',
+      userId: 'userId1234567890',
       message: 'ねこ！',
     } as const;
 

--- a/src/api/client/fetchCatMessage.ts
+++ b/src/api/client/fetchCatMessage.ts
@@ -12,8 +12,13 @@ export const fetchCatMessage: FetchCatMessage = async (dto) => {
     headers: {
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify({ catName: dto.catName, message: dto.message }),
+    body: JSON.stringify({
+      catName: dto.catName,
+      userId: dto.userId,
+      message: dto.message,
+    }),
   });
+
   const responseBody = (await response.json()) as FetchCatMessageResponse;
 
   const parseResult = fetchCatMessageResponseSchema.safeParse(responseBody);

--- a/src/app/api/cats/route.ts
+++ b/src/app/api/cats/route.ts
@@ -4,6 +4,7 @@ import { NextResponse, type NextRequest } from 'next/server';
 
 type RequestBody = {
   catName: string;
+  userId: string;
   message: string;
 };
 
@@ -53,7 +54,10 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
           process.env.API_BASIC_AUTH_CREDENTIALS
         )}`,
       },
-      body: JSON.stringify({ message: requestBody.message }),
+      body: JSON.stringify({
+        userId: requestBody.userId,
+        message: requestBody.message,
+      }),
     }
   );
   const responseBody = (await response.json()) as ResponseBody;

--- a/src/app/chat/_components/ChatContent/ChatContent.stories.tsx
+++ b/src/app/chat/_components/ChatContent/ChatContent.stories.tsx
@@ -8,7 +8,10 @@ import { ChatContentLayout } from './ChatContentLayout';
 const ChatContentWithLayout = ({ initChatMessages }: Props): JSX.Element => {
   return (
     <ChatContentLayout>
-      <ChatContent userId="userId1234567890" initChatMessages={initChatMessages} />
+      <ChatContent
+        userId="userId1234567890"
+        initChatMessages={initChatMessages}
+      />
     </ChatContentLayout>
   );
 };

--- a/src/app/chat/_components/ChatContent/ChatContent.stories.tsx
+++ b/src/app/chat/_components/ChatContent/ChatContent.stories.tsx
@@ -8,7 +8,7 @@ import { ChatContentLayout } from './ChatContentLayout';
 const ChatContentWithLayout = ({ initChatMessages }: Props): JSX.Element => {
   return (
     <ChatContentLayout>
-      <ChatContent initChatMessages={initChatMessages} />
+      <ChatContent userId="userId1234567890" initChatMessages={initChatMessages} />
     </ChatContentLayout>
   );
 };

--- a/src/app/chat/_components/ChatContent/ChatContent.tsx
+++ b/src/app/chat/_components/ChatContent/ChatContent.tsx
@@ -11,10 +11,14 @@ import {
 import { ChatMessagesList, type ChatMessages } from './ChatMessagesList';
 
 export type Props = {
+  userId: string;
   initChatMessages: ChatMessages;
 };
 
-export const ChatContent = ({ initChatMessages }: Props): JSX.Element => {
+export const ChatContent = ({
+  userId,
+  initChatMessages,
+}: Props): JSX.Element => {
   const [isLoading, setIsLoading] = useState(false);
 
   const [chatMessages, setChatMessages] =
@@ -49,6 +53,7 @@ export const ChatContent = ({ initChatMessages }: Props): JSX.Element => {
       try {
         const fetchCatMessageResponse = await fetchCatMessage({
           catName: 'moko',
+          userId,
           message,
         });
 

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -1,5 +1,6 @@
 import { ChatContent, ChatContentLayout } from '@/app/chat/_components';
 import type { NextPage } from 'next';
+import { v4 } from 'uuid';
 
 const chatMessages = [
   {
@@ -121,9 +122,11 @@ const chatMessages = [
 ];
 
 const ChatPage: NextPage = () => {
+  const anonymousUserId = v4();
+
   return (
     <ChatContentLayout>
-      <ChatContent initChatMessages={chatMessages} />
+      <ChatContent userId={anonymousUserId} initChatMessages={chatMessages} />
     </ChatContentLayout>
   );
 };

--- a/src/features/cat.ts
+++ b/src/features/cat.ts
@@ -1,5 +1,6 @@
 export type FetchCatMessageDto = {
   catName: 'moko';
+  userId: string;
   message: string;
 };
 


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/ai-cat-frontend/issues/11

# この PR で対応する範囲 / この PR で対応しない範囲

バックエンドAPIのURLを正式版に変更する。

# Storybook の URL、 スクリーンショット

UI変更は発生していないのでなし

# 変更点概要

バックエンドのAPIのURLが試作品として作った https://github.com/keitakn/chat-gpt-slack-bot に向いていたので正式版である https://github.com/nekochans/ai-cat-api をターゲットとするように変更。

正式版はユーザーIDを渡す必要があるので未ログインユーザーはUUID形式の値を生成して渡すように変更。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

特になし