### PR TITLE
Slackなどのアプリと同じくCommand+ Enter or Control + Enter でメッセージを送信するように変更

### DIFF
--- a/src/app/chat/_components/ChatContent/ChatContent.tsx
+++ b/src/app/chat/_components/ChatContent/ChatContent.tsx
@@ -115,7 +115,7 @@ export const ChatContent = ({
             <textarea
               id="message-input"
               name="message-input"
-              placeholder="Type your message here. Press Enter + Shift to send."
+              placeholder="Type your message here. Press Command + Enter or Control + Enter to send."
               className="w-full rounded-md py-3 pl-4 text-gray-600 placeholder:text-gray-600  focus:outline-none focus:placeholder:text-gray-400"
               ref={ref}
               onKeyDown={handleKeyDown}

--- a/src/app/chat/_components/ChatContent/ChatContent.tsx
+++ b/src/app/chat/_components/ChatContent/ChatContent.tsx
@@ -84,7 +84,7 @@ export const ChatContent = ({
       return;
     }
 
-    if (event.shiftKey && event.key === 'Enter') {
+    if (event.key === 'Enter' && (event.ctrlKey || event.metaKey)) {
       const submitEvent = new Event('submit', {
         bubbles: true,
         cancelable: true,


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/ai-cat-frontend/issues/33

# この PR で対応する範囲 / この PR で対応しない範囲

https://github.com/nekochans/ai-cat-frontend/issues/33 のDoneの定義を満たす実装が全て完了している事。

# Storybook の URL、 スクリーンショット

https://647ee6f3dfc9fdebe0ceca01-wtdnwovnuw.chromatic.com/?path=/story/app-chat-components-chatcontent--default

# 変更点概要

Slackなどのアプリと同じくCommand+ Enter or Control + Enter でメッセージを送信するように変更した。

PC版のLINEも同じ方法で送信だったので、そこに合わせたほうが良いと判断し本件を実施した。

ショートカットキーが変わったのでテキストボックスの `placeholder` も合わせて変更している。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

特になし