### PR TITLE
匿名のユーザーIDはエンドユーザーのIPアドレスを設定するように変更

### DIFF
--- a/src/app/api/cats/route.ts
+++ b/src/app/api/cats/route.ts
@@ -27,9 +27,9 @@ const rateLimit = new Ratelimit({
 export const runtime = 'edge';
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
-  const { success } = await rateLimit.limit(
-    request.ip != null ? request.ip : 'anonymous'
-  );
+  const requestIp = request.ip != null ? request.ip : 'anonymous';
+
+  const { success } = await rateLimit.limit(requestIp);
 
   if (!success) {
     const responseBody = {
@@ -55,11 +55,15 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
         )}`,
       },
       body: JSON.stringify({
-        userId: requestBody.userId,
+        // TODO ログイン機能が完成したら userId の設定をちゃんと行う
+        userId: requestIp === 'anonymous' ? requestBody.userId : requestIp,
         message: requestBody.message,
       }),
     }
   );
+
+  console.log(response);
+
   const responseBody = (await response.json()) as ResponseBody;
 
   return NextResponse.json(responseBody, { status: 201 });

--- a/src/app/api/cats/route.ts
+++ b/src/app/api/cats/route.ts
@@ -62,8 +62,6 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     }
   );
 
-  console.log(response);
-
   const responseBody = (await response.json()) as ResponseBody;
 
   return NextResponse.json(responseBody, { status: 201 });


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/ai-cat-frontend/issues/34

# この PR で対応する範囲 / この PR で対応しない範囲

https://github.com/nekochans/ai-cat-frontend/issues/34 のDoneの定義を満たす実装はこのPRで対応する。

# Storybook の URL、 スクリーンショット

UI変更は発生していないのでなし。

# 変更点概要

タイトルの通り、匿名のユーザーIDはエンドユーザーのIPアドレスを設定するように変更。

元々は匿名のIDを生成していたが、これだとページをリロードすると会話履歴が失われてしまう。

同一のWi-Fi環境からは同じ人物と見なされてしまうデメリットがあるが他に会話履歴を引き継げる良い方法が思いつかなかったので一旦初期リリースはこの実装でいこうと思う。

# レビュアーに重点的にチェックして欲しい点

匿名ユーザーの会話履歴を引き継ぐ良い案があれば知りたい:pray:

# 補足情報

どちらにせよ、今の状況だとインスタンスの再起動でも会話履歴が失われたりするので、会話履歴の本格的な扱いはやはりログイン機能が出来ないとどうしようもならない部分が大きい。