### PR TITLE
Prettier を3系の最新安定版に更新

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,5 +1,6 @@
 {
   "singleQuote": true,
   "endOfLine": "auto",
+  "plugins": ["@ianvs/prettier-plugin-sort-imports"],
   "importOrderTypeScriptVersion": "5.1.6"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
         "msw": "^1.2.2",
         "msw-storybook-addon": "^1.8.0",
         "npm-run-all": "^4.1.5",
-        "prettier": "^2.8.8",
+        "prettier": "^3.0.0",
         "storybook": "^7.0.26",
         "whatwg-fetch": "^3.6.2"
       }
@@ -4890,6 +4890,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@storybook/cli/node_modules/prettier": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/@storybook/cli/node_modules/strip-final-newline": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
@@ -5166,6 +5181,21 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/@storybook/codemod/node_modules/prettier": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/@storybook/codemod/node_modules/semver": {
@@ -16354,15 +16384,15 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.0.tgz",
+      "integrity": "sha512-zBf5eHpwHOGPC47h0zrPyNn+eAEIdEzfywMoYn2XPi0P44Zp0tSq64rq0xAREh4auw2cJZHo9QUob+NqCQky4g==",
       "dev": true,
       "bin": {
-        "prettier": "bin-prettier.js"
+        "prettier": "bin/prettier.cjs"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
@@ -23293,6 +23323,12 @@
             "mimic-fn": "^2.1.0"
           }
         },
+        "prettier": {
+          "version": "2.8.8",
+          "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+          "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+          "dev": true
+        },
         "strip-final-newline": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
@@ -23522,6 +23558,12 @@
           "version": "2.2.3",
           "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
           "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+          "dev": true
+        },
+        "prettier": {
+          "version": "2.8.8",
+          "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+          "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
           "dev": true
         },
         "semver": {
@@ -31927,9 +31969,9 @@
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="
     },
     "prettier": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.0.tgz",
+      "integrity": "sha512-zBf5eHpwHOGPC47h0zrPyNn+eAEIdEzfywMoYn2XPi0P44Zp0tSq64rq0xAREh4auw2cJZHo9QUob+NqCQky4g==",
       "dev": true
     },
     "pretty-error": {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "msw": "^1.2.2",
     "msw-storybook-addon": "^1.8.0",
     "npm-run-all": "^4.1.5",
-    "prettier": "^2.8.8",
+    "prettier": "^3.0.0",
     "storybook": "^7.0.26",
     "whatwg-fetch": "^3.6.2"
   },

--- a/src/api/client/__tests__/fetchCatMessage.spec.ts
+++ b/src/api/client/__tests__/fetchCatMessage.spec.ts
@@ -41,7 +41,7 @@ describe('src/api/client/fetchCatMessage.ts fetchCatMessage TestCases', () => {
 
   it('should InvalidResponseBodyError Throw, because unexpected response body', async () => {
     mockServer.use(
-      rest.post('/api/cats', mockFetchCatMessageUnexpectedResponseBody)
+      rest.post('/api/cats', mockFetchCatMessageUnexpectedResponseBody),
     );
 
     const dto = {
@@ -51,7 +51,7 @@ describe('src/api/client/fetchCatMessage.ts fetchCatMessage TestCases', () => {
     } as const;
 
     await expect(fetchCatMessage(dto)).rejects.toThrow(
-      InvalidResponseBodyError
+      InvalidResponseBodyError,
     );
   });
 });

--- a/src/app/api/cats/route.ts
+++ b/src/app/api/cats/route.ts
@@ -28,7 +28,7 @@ export const runtime = 'edge';
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
   const { success } = await rateLimit.limit(
-    request.ip != null ? request.ip : 'anonymous'
+    request.ip != null ? request.ip : 'anonymous',
   );
 
   if (!success) {
@@ -51,14 +51,14 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       headers: {
         'Content-Type': 'application/json',
         Authorization: `Basic ${String(
-          process.env.API_BASIC_AUTH_CREDENTIALS
+          process.env.API_BASIC_AUTH_CREDENTIALS,
         )}`,
       },
       body: JSON.stringify({
         userId: requestBody.userId,
         message: requestBody.message,
       }),
-    }
+    },
   );
   const responseBody = (await response.json()) as ResponseBody;
 

--- a/src/app/chat/[catId]/layout.tsx
+++ b/src/app/chat/[catId]/layout.tsx
@@ -19,7 +19,7 @@ export const generateMetadata = async (
   // eslint-disable-next-line
   { params }: Props,
   // eslint-disable-next-line
-  parent: ResolvingMetadata
+  parent: ResolvingMetadata,
 ): Promise<Metadata> => {
   if (!isCatId(params.catId)) {
     notFound();
@@ -28,7 +28,7 @@ export const generateMetadata = async (
   return {
     title: `AI Cat ${extractCatNameById(params.catId)}ちゃん🐱`,
     description: `ねこのAI（${extractCatNameById(
-      params.catId
+      params.catId,
     )}）とお話しよう🐱`,
   };
 };

--- a/src/app/chat/_components/ChatContent/__tests__/ChatHeader.spec.tsx
+++ b/src/app/chat/_components/ChatContent/__tests__/ChatHeader.spec.tsx
@@ -10,7 +10,7 @@ describe('src/app/chat/_components/ChatContent/ChatHeader.tsx TestCases', () => 
 
     expect(screen.getByRole('img', { name: expectedCatName })).toHaveAttribute(
       'alt',
-      expectedCatName
+      expectedCatName,
     );
 
     expect(screen.getByText(expectedCatName)).toBeInTheDocument();

--- a/src/features/__tests__/cat/extractCatNameById.spec.ts
+++ b/src/features/__tests__/cat/extractCatNameById.spec.ts
@@ -15,7 +15,7 @@ describe('src/features/cat.ts extractCatNameById TestCases', () => {
     'should return catName. catId: $catId',
     ({ catId, expected }: TestTable) => {
       expect(extractCatNameById(catId)).toStrictEqual(expected);
-    }
+    },
   );
 
   it.each`

--- a/src/features/cat.ts
+++ b/src/features/cat.ts
@@ -19,7 +19,7 @@ export type FetchCatMessageResponse = {
 };
 
 export type FetchCatMessage = (
-  dto: FetchCatMessageDto
+  dto: FetchCatMessageDto,
 ) => Promise<FetchCatMessageResponse>;
 
 export const extractCatNameById = (catId: CatId): CatName => {

--- a/src/mocks/api/internal/cats/mockFetchCatMessage.ts
+++ b/src/mocks/api/internal/cats/mockFetchCatMessage.ts
@@ -16,6 +16,6 @@ export const mockFetchCatMessage: ResponseResolver<
     ctx.json({
       message:
         'こんにちは🐱もことお話しようにゃん🐱お名前を教えてほしいにゃん🐱',
-    })
+    }),
   );
 };

--- a/src/mocks/api/internal/cats/mockFetchCatMessageUnexpectedResponseBody.ts
+++ b/src/mocks/api/internal/cats/mockFetchCatMessageUnexpectedResponseBody.ts
@@ -16,6 +16,6 @@ export const mockFetchCatMessageUnexpectedResponseBody: ResponseResolver<
     ctx.json({
       catMessageText:
         'こんにちは🐱もことお話しようにゃん🐱お名前を教えてほしいにゃん🐱',
-    })
+    }),
   );
 };

--- a/src/utils/sleep.ts
+++ b/src/utils/sleep.ts
@@ -3,7 +3,7 @@ const millisecond = 1000;
 const defaultWaitSeconds = 1;
 
 export const sleep = async (
-  waitSeconds: number = defaultWaitSeconds
+  waitSeconds: number = defaultWaitSeconds,
 ): Promise<void> => {
   await new Promise<void>((resolve) => {
     setTimeout(() => {


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/ai-cat-frontend/issues/44

# この PR で対応する範囲 / この PR で対応しない範囲

https://github.com/nekochans/ai-cat-frontend/issues/44 のDoneの定義を満たす実装は全てこのPR内で実施する。

# Storybook の URL、 スクリーンショット

UI変更はないのでなし。

# 変更点概要

PRタイトルの通りPrettier を3系の最新安定版に更新。

`@ianvs/prettier-plugin-sort-imports` が動作しなくなってしまったが `.prettierrc.json` に `"plugins": ["@ianvs/prettier-plugin-sort-imports"],` を明示的に指定するようにする事で正常に利用出来るようになった。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

特になし