### PR TITLE
エラーページ用のComponentを作成

### DIFF
--- a/src/app/_components/ErrorTemplate/BackToTopLink.tsx
+++ b/src/app/_components/ErrorTemplate/BackToTopLink.tsx
@@ -1,0 +1,13 @@
+import Link from 'next/link';
+
+export const BackToTopLink = (): JSX.Element => {
+  return (
+    <Link
+      href="/"
+      className="text-sm font-semibold leading-6 text-orange-500 hover:text-orange-400"
+      prefetch={false}
+    >
+      <span aria-hidden="true">&larr;Back to Top</span>
+    </Link>
+  );
+};

--- a/src/app/_components/ErrorTemplate/ErrorResetButton.tsx
+++ b/src/app/_components/ErrorTemplate/ErrorResetButton.tsx
@@ -1,0 +1,14 @@
+type Props = {
+  resetFunc: () => void;
+};
+
+export const ErrorResetButton = ({ resetFunc }: Props): JSX.Element => {
+  return (
+    <button
+      className="rounded-md bg-orange-500 px-3.5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-orange-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
+      onClick={resetFunc}
+    >
+      もう一度試す
+    </button>
+  );
+};

--- a/src/app/_components/ErrorTemplate/ErrorTemplate.stories.tsx
+++ b/src/app/_components/ErrorTemplate/ErrorTemplate.stories.tsx
@@ -1,0 +1,54 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ErrorTemplate } from './ErrorTemplate';
+
+const meta: Meta = {
+  component: ErrorTemplate,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ErrorTemplate>;
+
+const TestComponent = (): JSX.Element => {
+  return (
+    <ul>
+      <li className="mt-2 text-sm leading-6 text-gray-600">テスト1</li>
+      <li className="mt-2 text-sm leading-6 text-gray-600">テスト2</li>
+      <li className="mt-2 text-sm leading-6 text-gray-600">テスト3</li>
+    </ul>
+  );
+};
+
+export const DefaultNotFound: Story = {
+  args: {
+    errorCode: 404,
+  },
+};
+
+export const NotFoundWithChildren: Story = {
+  args: {
+    errorCode: 404,
+    children: <TestComponent />,
+  },
+};
+
+export const DefaultInternalServerError = {
+  args: {
+    errorCode: 500,
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+    resetFunc: () => {
+      console.log('reset error');
+    },
+  },
+};
+
+export const InternalServerErrorWithChildren = {
+  args: {
+    errorCode: 500,
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+    resetFunc: () => {
+      console.log('reset error');
+    },
+    children: <TestComponent />,
+  },
+};

--- a/src/app/_components/ErrorTemplate/ErrorTemplate.tsx
+++ b/src/app/_components/ErrorTemplate/ErrorTemplate.tsx
@@ -1,0 +1,105 @@
+import { Footer, Header } from '@/app/_components';
+import { BackToTopLink } from '@/app/_components/ErrorTemplate/BackToTopLink';
+import { ErrorResetButton } from '@/app/_components/ErrorTemplate/ErrorResetButton';
+import { ExhaustiveError } from '@/utils';
+import Image from 'next/image';
+import type { JSX, ReactNode } from 'react';
+
+type ErrorCode = 404 | 500;
+
+type Props = {
+  errorCode: ErrorCode;
+  resetFunc?: () => void;
+  children?: ReactNode;
+};
+
+const showErrorImage = (errorCode: ErrorCode): JSX.Element => {
+  switch (errorCode) {
+    case 404:
+      return (
+        <Image
+          src="/404.webp"
+          width={300}
+          height={300}
+          alt="Cat in a Box"
+          className="mx-auto"
+        />
+      );
+    case 500:
+      return (
+        <Image
+          src="/500.webp"
+          width={300}
+          height={300}
+          alt="Cat on a keyboard"
+          className="mx-auto"
+        />
+      );
+    default:
+      throw new ExhaustiveError(errorCode);
+  }
+};
+
+const showErrorMessage = (errorCode: ErrorCode): string => {
+  switch (errorCode) {
+    case 404:
+      return 'Page not found';
+    case 500:
+      return 'Internal Server Error';
+    default:
+      throw new ExhaustiveError(errorCode);
+  }
+};
+
+const showErrorDiscription = (errorCode: ErrorCode) => {
+  switch (errorCode) {
+    case 404:
+      return 'Sorry, we couldn’t find the page you’re looking for😿';
+    case 500:
+      return 'Sorry, An unexpected error has occurred. Please try after a while😿';
+    default:
+      throw new ExhaustiveError(errorCode);
+  }
+};
+
+export const ErrorTemplate = ({
+  errorCode,
+  resetFunc,
+  children,
+}: Props): JSX.Element => {
+  return (
+    <div className="flex h-screen flex-col bg-yellow-100">
+      <Header enableLoginLink={false} />
+      <main className="mx-auto w-full max-w-7xl px-6 pb-16 pt-10 sm:pb-24 lg:px-8">
+        <div className="mx-auto mt-20 max-w-2xl text-center sm:mt-24">
+          <p className="text-6xl font-semibold leading-8 text-orange-500">
+            {errorCode}
+          </p>
+          {showErrorImage(errorCode)}
+          <h1 className="mt-4 text-3xl font-bold tracking-tight text-gray-900 sm:text-5xl">
+            {showErrorMessage(errorCode)}
+          </h1>
+          <p className="mt-4 text-base leading-7 text-gray-600 sm:mt-6 sm:text-lg sm:leading-8">
+            {showErrorDiscription(errorCode)}
+          </p>
+        </div>
+        <div className="mx-auto mt-16 flow-root max-w-lg sm:mt-20">
+          <div className="flex justify-center">
+            {children != null ? children : ''}
+          </div>
+          <div className="mt-10 flex justify-center">
+            {errorCode === 404 ? <BackToTopLink /> : ''}
+            {errorCode === 500 && resetFunc != null ? (
+              <ErrorResetButton resetFunc={resetFunc} />
+            ) : (
+              ''
+            )}
+          </div>
+        </div>
+      </main>
+      <div className="mt-auto">
+        <Footer />
+      </div>
+    </div>
+  );
+};

--- a/src/app/_components/ErrorTemplate/index.ts
+++ b/src/app/_components/ErrorTemplate/index.ts
@@ -1,0 +1,1 @@
+export { ErrorTemplate } from './ErrorTemplate';

--- a/src/app/_components/index.ts
+++ b/src/app/_components/index.ts
@@ -1,2 +1,3 @@
 export { Footer } from './Footer';
 export { Header } from './Header';
+export { ErrorTemplate } from './ErrorTemplate';

--- a/src/app/chat/[catId]/error.tsx
+++ b/src/app/chat/[catId]/error.tsx
@@ -1,7 +1,6 @@
 'use client';
 
-import { Footer, Header } from '@/app/_components';
-import Image from 'next/image';
+import { ErrorTemplate } from '@/app/_components';
 
 type Props = {
   error: Error & { digest?: string };
@@ -9,45 +8,7 @@ type Props = {
 };
 
 const Error = ({ reset }: Props): JSX.Element => {
-  return (
-    <div className="flex h-screen flex-col bg-yellow-100">
-      <Header enableLoginLink={false} />
-      <main className="mx-auto w-full max-w-7xl px-6 pb-16 pt-10 sm:pb-24 lg:px-8">
-        <div className="mx-auto mt-20 max-w-2xl text-center sm:mt-24">
-          <p className="text-6xl font-semibold leading-8 text-orange-500">
-            500
-          </p>
-          <Image
-            src="/500.webp"
-            width={300}
-            height={300}
-            alt="Cat on a keyboard"
-            className="mx-auto"
-          />
-          <h1 className="mt-4 text-3xl font-bold tracking-tight text-gray-900 sm:text-5xl">
-            Internal Server Error
-          </h1>
-          <p className="mt-4 text-base leading-7 text-gray-600 sm:mt-6 sm:text-lg sm:leading-8">
-            Sorry, An unexpected error has occurred. Please try after a while.😿
-          </p>
-        </div>
-        <div className="mx-auto mt-16 flow-root max-w-lg sm:mt-20">
-          <h2 className="sr-only">Popular pages</h2>
-          <div className="mt-10 flex justify-center">
-            <button
-              className="rounded-md bg-orange-500 px-3.5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-orange-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
-              onClick={reset}
-            >
-              もう一度試す
-            </button>
-          </div>
-        </div>
-      </main>
-      <div className="mt-auto">
-        <Footer />
-      </div>
-    </div>
-  );
+  return <ErrorTemplate errorCode={500} resetFunc={reset} />;
 };
 
 export default Error;

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,49 +1,8 @@
-import { Footer, Header } from '@/app/_components';
-import Image from 'next/image';
-import Link from 'next/link';
+import { ErrorTemplate } from '@/app/_components';
 import type { JSX } from 'react';
 
 const NotFound = (): JSX.Element => {
-  return (
-    <div className="flex h-screen flex-col bg-yellow-100">
-      <Header enableLoginLink={false} />
-      <main className="mx-auto w-full max-w-7xl px-6 pb-16 pt-10 sm:pb-24 lg:px-8">
-        <div className="mx-auto mt-20 max-w-2xl text-center sm:mt-24">
-          <p className="text-6xl font-semibold leading-8 text-orange-500">
-            404
-          </p>
-          <Image
-            src="/404.webp"
-            width={300}
-            height={300}
-            alt="Cat in a Box"
-            className="mx-auto"
-          />
-          <h1 className="mt-4 text-3xl font-bold tracking-tight text-gray-900 sm:text-5xl">
-            Page not found
-          </h1>
-          <p className="mt-4 text-base leading-7 text-gray-600 sm:mt-6 sm:text-lg sm:leading-8">
-            Sorry, we couldn’t find the page you’re looking for😿
-          </p>
-        </div>
-        <div className="mx-auto mt-16 flow-root max-w-lg sm:mt-20">
-          <h2 className="sr-only">Popular pages</h2>
-          <div className="mt-10 flex justify-center">
-            <Link
-              href="/"
-              className="text-sm font-semibold leading-6 text-orange-500 hover:text-orange-400"
-              prefetch={false}
-            >
-              <span aria-hidden="true">&larr;Back to Top</span>
-            </Link>
-          </div>
-        </div>
-      </main>
-      <div className="mt-auto">
-        <Footer />
-      </div>
-    </div>
-  );
+  return <ErrorTemplate errorCode={404} />;
 };
 
 export default NotFound;


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/ai-cat-frontend/issues/41

# この PR で対応する範囲 / この PR で対応しない範囲

エラーページ用のComponentが作成され、各エラーページをエラーページ用のComponentを使った形に置き換える。

# Storybook の URL、 スクリーンショット

https://647ee6f3dfc9fdebe0ceca01-lzmtkwfzrq.chromatic.com/?path=/story/app-components-errortemplate--default-not-found

# 変更点概要

`ErrorTemplate` を作成。

作成した 404, 500 エラーページを再現出来るようになっている。

今後503等の別のエラーが増えた時も対応可能になっている。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

特になし