### PR TITLE
Description のtypo を修正

### DIFF
--- a/src/app/_components/ErrorTemplate/ErrorTemplate.tsx
+++ b/src/app/_components/ErrorTemplate/ErrorTemplate.tsx
@@ -51,7 +51,7 @@ const showErrorMessage = (errorCode: ErrorCode): string => {
   }
 };
 
-const showErrorDiscription = (errorCode: ErrorCode) => {
+const showErrorDescription = (errorCode: ErrorCode) => {
   switch (errorCode) {
     case 404:
       return 'Sorry, we couldn’t find the page you’re looking for😿';
@@ -80,7 +80,7 @@ export const ErrorTemplate = ({
             {showErrorMessage(errorCode)}
           </h1>
           <p className="mt-4 text-base leading-7 text-gray-600 sm:mt-6 sm:text-lg sm:leading-8">
-            {showErrorDiscription(errorCode)}
+            {showErrorDescription(errorCode)}
           </p>
         </div>
         <div className="mx-auto mt-16 flow-root max-w-lg sm:mt-20">


### PR DESCRIPTION
# issueURL

なし

# この PR で対応する範囲 / この PR で対応しない範囲

PRタイトルの通り、`showErrorDescription` のtypoを修正する。

# Storybook の URL、 スクリーンショット

UI変更はないのでなし。

# 変更点概要

`showErrorDescription` のtypoを修正。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

特になし