### PR TITLE
API側で conversationId, message以外のレスポンスが消えたので対応

### DIFF
--- a/src/app/chat/_components/ChatContent/ChatContent.tsx
+++ b/src/app/chat/_components/ChatContent/ChatContent.tsx
@@ -3,7 +3,6 @@
 import { fetchCatMessage } from '@/api/client/fetchCatMessage';
 import { TooManyRequestsError } from '@/api/errors';
 import { InvalidResponseBodyError } from '@/errors';
-import { isCatId, type CatId } from '@/features';
 import {
   useRef,
   useState,
@@ -27,15 +26,11 @@ export type Props = {
 
 const fetchCatMessageResponseSchema = z.object({
   conversationId: z.string().min(36).max(36),
-  userId: z.string().min(36).max(36),
-  catId: z.string().refine((value) => isCatId(value)),
   message: z.string().min(1),
 });
 
 type FetchCatMessageResponse = {
   conversationId: string;
-  userId: string;
-  catId: CatId;
   message: string;
 };
 


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/ai-cat-api/issues/44

# この PR で対応する範囲 / この PR で対応しない範囲

https://github.com/nekochans/ai-cat-api/issues/44 の変更に合わせてフロント側が正常動作するように必要な実装を行う

# Storybook の URL、 スクリーンショット

なし

# 変更点概要

API側で conversationId, message以外のStreamingレスポンスが消えたので対応。

元々この2つの値以外は利用していなかったので特に問題はなし。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

デプロイのタイミングに注意、先にバックエンド側を本番反映する必要がある。