### PR TITLE
LLMの応答を返すエンドポイントに maxDurationの設定

### DIFF
--- a/src/app/api/cats/route.ts
+++ b/src/app/api/cats/route.ts
@@ -23,6 +23,8 @@ const rateLimit = new Ratelimit({
 
 export const runtime = 'edge';
 
+export const maxDuration = 180;
+
 export async function POST(
   request: NextRequest,
 ): Promise<Response | NextResponse> {


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/ai-cat-frontend/issues/63

# この PR で対応する範囲 / この PR で対応しない範囲

https://github.com/nekochans/ai-cat-frontend/issues/63 のDoneの定義を満たす実装は全てこのPRで実装します。

# Storybook の URL、 スクリーンショット

UI変更はないのでなし。

# 変更点概要

LLMのメッセージ生成は時間がかかるので、以下の公式情報を参考に長めのタイムアウト（180秒）を明示的に指定するように変更。

https://vercel.com/changelog/serverless-functions-can-now-run-up-to-5-minutes

https://vercel.com/docs/functions/serverless-functions/runtimes#maxduration

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

特になし