### PR TITLE
メッセージ追加時の画像を /no-avatar.webp に変更

### DIFF
--- a/src/app/chat/_components/ChatContent/ChatContent.tsx
+++ b/src/app/chat/_components/ChatContent/ChatContent.tsx
@@ -64,7 +64,7 @@ export const ChatContent = ({
         role: 'user',
         name: 'User',
         message,
-        avatarUrl: 'https://avatars.githubusercontent.com/u/11032365?s=96&v=4',
+        avatarUrl: '/no-avatar.webp',
       } as const satisfies ChatMessage;
       const newChatMessages = [...chatMessages, ...[newUserMessage]];
 


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/ai-cat-frontend/issues/49

# この PR で対応する範囲 / この PR で対応しない範囲

メッセージ追加時の画像を `/no-avatar.webp` に変更する。

# Storybook の URL、 スクリーンショット

<img width="1419" alt="2024-02-01 23 58 27" src="https://github.com/nekochans/ai-cat-frontend/assets/11032365/5bf4f449-6d61-47ce-b317-665c9392de02">

# 変更点概要

現状ログイン機能が未実装でゲストユーザー向けの機能しか実装されていないのでメッセージ送信時のユーザーアバターを `/no-avatar.webp` に変更。（今は自分のGitHubのアバターが出てしまっている）

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

特になし