### PR TITLE
基本的なMetaタグの設定を追加

### DIFF
--- a/src/app/chat/[catId]/page.tsx
+++ b/src/app/chat/[catId]/page.tsx
@@ -1,8 +1,27 @@
 import { ChatContent, ChatContentLayout } from '@/app/chat/_components';
-import type { NextPage } from 'next';
+import { extractCatNameById, type CatId } from '@/features';
+import type { Metadata, NextPage } from 'next';
 import { v4 } from 'uuid';
 
-const ChatPage: NextPage = () => {
+type Props = {
+  params: { catId: CatId };
+};
+
+export const generateMetadata = async ({
+  params,
+  // eslint-disable-next-line @typescript-eslint/require-await
+}: Props): Promise<Metadata> => {
+  const catId = params.catId;
+
+  return {
+    title: `AI Meow Cat ${extractCatNameById(catId)}`,
+    description: `AIねこの「${extractCatNameById(
+      catId,
+    )}ちゃん」とお話ができます🐱分からない事を何でも聞いてみよう！`,
+  };
+};
+
+const ChatPage: NextPage<Props> = () => {
   const anonymousUserId = v4();
 
   return (

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -10,8 +10,9 @@ const font = Noto_Sans_JP({
 });
 
 export const metadata = {
-  title: 'AI Cat🐱',
-  description: 'ねこのAIとお話しよう🐱',
+  title: 'AI Meow Cat',
+  description:
+    'ねこの人格を持ったAIとお話ができます🐱分からない事を何でも聞いてみよう！',
 };
 
 type Props = {


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/ai-cat-frontend/issues/12

# この PR で対応する範囲 / この PR で対応しない範囲

https://github.com/nekochans/ai-cat-frontend/issues/12 の完了の定義に記載されている通りtitle, descriptionの設定を完了させる。

# Storybook の URL、 スクリーンショット

UI変更はないのでなし

# 変更点概要

タイトルの通り。

`/chat/{catId}` に関しては動的な生成が必要なので以下のドキュメントを参考に `generateMetadata` での設定を行っている。

https://nextjs.org/docs/app/api-reference/functions/generate-metadata#generatemetadata-function

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

特になし