### PR TITLE
Streamingの更新速度が早すぎるので useTransition を使ってコントロールするように変更

### DIFF
--- a/src/app/chat/_components/ChatContent/ChatContent.tsx
+++ b/src/app/chat/_components/ChatContent/ChatContent.tsx
@@ -8,10 +8,10 @@ import {
   type GenerateCatMessageResponse,
 } from '@/features';
 import { type ChatMessage, type ChatMessages } from '@/features/chat';
-import { sleep } from '@/utils';
 import {
   useRef,
   useState,
+  useTransition,
   type FormEvent,
   type JSX,
   type KeyboardEvent,
@@ -46,6 +46,8 @@ export const ChatContent = ({
   >('');
 
   const [conversationId, setConversationId] = useState<string>('');
+
+  const [isPending, startTransition] = useTransition();
 
   const ref = useRef<HTMLTextAreaElement>(null);
 
@@ -134,10 +136,9 @@ export const ChatContent = ({
 
             newResponseMessage += responseMessage;
 
-            // TODO あまり良い方法ではないがレンダリングがスキップされてメッセージが欠落してしまうのでsleepで対応
-            await sleep(0.05);
-
-            setStreamingMessage(newResponseMessage);
+            startTransition(() => {
+              setStreamingMessage(newResponseMessage);
+            });
           }
 
           await readStream();
@@ -199,7 +200,7 @@ export const ChatContent = ({
   return (
     <>
       <ChatMessagesList chatMessages={chatMessages} isLoading={isLoading} />
-      {streamingMessage !== '' ? (
+      {streamingMessage !== '' && !isPending ? (
         <StreamingCatMessage
           name="もこちゃん"
           avatarUrl="/cats/moko.webp"


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/ai-cat-frontend/issues/59

# この PR で対応する範囲 / この PR で対応しない範囲

https://github.com/nekochans/ai-cat-frontend/issues/59 の問題を解決する為にStreamingMessageの処理に `useTransition` を利用した形に変更する。

# Storybook の URL、 スクリーンショット

https://647ee6f3dfc9fdebe0ceca01-xtrsinllrq.chromatic.com/?path=/story/app-chat-components-chatcontent--default

# 変更点概要

Streamingの更新速度が早すぎてメッセージが欠落してしまうので `useTransition` を利用して `isPending = false` の場合のみ表示するように変更した。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

特になし