### PR TITLE
StreamingMessage のレンダリング部分で useDeferredValue を利用するように変更

### DIFF
--- a/src/app/chat/_components/ChatContent/ChatContent.tsx
+++ b/src/app/chat/_components/ChatContent/ChatContent.tsx
@@ -9,9 +9,9 @@ import {
 } from '@/features';
 import { type ChatMessage, type ChatMessages } from '@/features/chat';
 import {
+  useDeferredValue,
   useRef,
   useState,
-  useTransition,
   type FormEvent,
   type JSX,
   type KeyboardEvent,
@@ -40,14 +40,14 @@ export const ChatContent = ({
 
   const [streamingMessage, setStreamingMessage] = useState<string>('');
 
+  const deferredStreamingMessage = useDeferredValue(streamingMessage);
+
   const [chatErrorType, setChatChatErrorType] = useState<
     // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
     ChatErrorType | string
   >('');
 
   const [conversationId, setConversationId] = useState<string>('');
-
-  const [isPending, startTransition] = useTransition();
 
   const ref = useRef<HTMLTextAreaElement>(null);
 
@@ -136,9 +136,7 @@ export const ChatContent = ({
 
             newResponseMessage += responseMessage;
 
-            startTransition(() => {
-              setStreamingMessage(newResponseMessage);
-            });
+            setStreamingMessage(newResponseMessage);
           }
 
           await readStream();
@@ -200,11 +198,11 @@ export const ChatContent = ({
   return (
     <>
       <ChatMessagesList chatMessages={chatMessages} isLoading={isLoading} />
-      {streamingMessage !== '' && !isPending ? (
+      {deferredStreamingMessage ? (
         <StreamingCatMessage
           name="もこちゃん"
           avatarUrl="/cats/moko.webp"
-          message={streamingMessage}
+          message={deferredStreamingMessage}
         />
       ) : (
         ''


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/ai-cat-frontend/issues/90

# この PR で対応する範囲 / この PR で対応しない範囲

https://github.com/nekochans/ai-cat-frontend/issues/90 に記載してある通り `useDeferredValue` を使った形に変更する。

# Storybook の URL、 スクリーンショット

https://647ee6f3dfc9fdebe0ceca01-pidfeklkss.chromatic.com/?path=/story/app-chat-components-chatcontent--default

# 変更点概要

StreamingMessage のレンダリング部分で `useDeferredValue` を利用するように変更した。

以前は `useTransition` を利用していたがユースケース的に `useDeferredValue` のほうが適切と判断しました。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

特になし