### PR TITLE
JSONデータが複数行に分かれてしまうケースがあるので対応

### DIFF
--- a/src/app/chat/_components/ChatContent/ChatContent.tsx
+++ b/src/app/chat/_components/ChatContent/ChatContent.tsx
@@ -117,24 +117,15 @@ export const ChatContent = ({
             .decode(value)
             .split('\n\n')
             .map((line) => {
+              console.log('LINE');
               console.log(line);
-              // この条件分岐に当てはまる時は完全なJSON文字列
-              if (line.startsWith('data:') && line.includes('}')) {
-                partialLine = line;
-                const jsonString = partialLine.trim().split('data: ')[1];
-                try {
-                  const parsedJson = JSON.parse(jsonString) as unknown;
+              console.log('LINE');
 
-                  return isGenerateCatMessageResponse(parsedJson)
-                    ? parsedJson
-                    : null;
-                } catch {
-                  return null;
-                } finally {
-                  partialLine = '';
-                }
-              }
+              console.log('partialLine');
+              console.log(partialLine);
+              console.log('partialLine');
 
+              // partialLine が完全なJSON文字列の場合はParseを実行する
               if (
                 partialLine.startsWith('data:') &&
                 partialLine.includes('{') &&
@@ -154,6 +145,28 @@ export const ChatContent = ({
                 }
               }
 
+              // この条件分岐に当てはまる時は完全なJSON文字列
+              if (
+                line.startsWith('data:') &&
+                line.includes('{') &&
+                line.includes('}')
+              ) {
+                partialLine = line;
+                const jsonString = partialLine.trim().split('data: ')[1];
+                try {
+                  const parsedJson = JSON.parse(jsonString) as unknown;
+
+                  return isGenerateCatMessageResponse(parsedJson)
+                    ? parsedJson
+                    : null;
+                } catch {
+                  return null;
+                } finally {
+                  partialLine = '';
+                }
+              }
+
+              // ここに到達する場合は line は不完全なJSON文字列なので partialLine に代入する
               if (line.startsWith('data:')) {
                 partialLine = line;
               } else {

--- a/src/app/chat/_components/ChatContent/ChatContent.tsx
+++ b/src/app/chat/_components/ChatContent/ChatContent.tsx
@@ -8,6 +8,7 @@ import {
   type GenerateCatMessageResponse,
 } from '@/features';
 import { type ChatMessage, type ChatMessages } from '@/features/chat';
+import { mightExtractJsonFromSsePayload } from '@/utils';
 import {
   useDeferredValue,
   useRef,
@@ -126,12 +127,8 @@ export const ChatContent = ({
               }
 
               // partialLine が完全なJSON文字列の場合はParseを実行する
-              if (
-                partialLine.startsWith('data:') &&
-                partialLine.includes('{') &&
-                partialLine.includes('}')
-              ) {
-                const jsonString = partialLine.trim().split('data: ')[1];
+              const jsonString = mightExtractJsonFromSsePayload(partialLine);
+              if (jsonString) {
                 try {
                   const parsedJson = JSON.parse(jsonString) as unknown;
 

--- a/src/app/chat/_components/ChatContent/ChatContent.tsx
+++ b/src/app/chat/_components/ChatContent/ChatContent.tsx
@@ -125,8 +125,14 @@ export const ChatContent = ({
               if (line.startsWith('data:')) {
                 partialLine = line;
               } else {
+                console.log('if文の中のpartialLine1');
+                console.log(partialLine);
+                console.log('if文の中のpartialLine1');
                 // この条件分岐に当てはまる場合は partialLine に続きのJSON文字列を結合する
                 partialLine = partialLine + line;
+                console.log('if文の中のpartialLine2');
+                console.log(partialLine);
+                console.log('if文の中のpartialLine2');
               }
 
               console.log('partialLine');

--- a/src/app/chat/_components/ChatContent/ChatContent.tsx
+++ b/src/app/chat/_components/ChatContent/ChatContent.tsx
@@ -123,7 +123,10 @@ export const ChatContent = ({
 
               // ここに到達する場合は line は不完全なJSON文字列なので partialLine に代入する
               if (line.startsWith('data:')) {
+                console.log('欠損データが最初にpartialLineに代入される');
                 partialLine = line;
+                console.log(partialLine);
+                console.log('欠損データが最初にpartialLineに代入される');
               } else {
                 console.log('if文の中のpartialLine1');
                 console.log(partialLine);
@@ -155,6 +158,7 @@ export const ChatContent = ({
                 } catch {
                   return null;
                 } finally {
+                  console.log('partialLineのリセットが呼ばれていないかテスト1');
                   partialLine = '';
                 }
               }
@@ -175,6 +179,9 @@ export const ChatContent = ({
                 } catch {
                   return null;
                 } finally {
+
+                  console.log('partialLineのリセットが呼ばれていないかテスト2');
+
                   partialLine = '';
                 }
               }

--- a/src/app/chat/_components/ChatContent/ChatContent.tsx
+++ b/src/app/chat/_components/ChatContent/ChatContent.tsx
@@ -105,13 +105,13 @@ export const ChatContent = ({
         const reader = body.getReader();
         const decoder = new TextDecoder();
 
+        let partialLine = '';
+
         const readStream = async (): Promise<undefined> => {
           const { done, value } = await reader.read();
           if (done) {
             return;
           }
-
-          let partialLine = '';
 
           const objects = decoder
             .decode(value)

--- a/src/app/chat/_components/ChatContent/ChatContent.tsx
+++ b/src/app/chat/_components/ChatContent/ChatContent.tsx
@@ -117,30 +117,13 @@ export const ChatContent = ({
             .decode(value)
             .split('\n\n')
             .map((line) => {
-              console.log('LINE');
-              console.log(line);
-              console.log('LINE');
-
               // ここに到達する場合は line は不完全なJSON文字列なので partialLine に代入する
               if (line.startsWith('data:')) {
-                console.log('欠損データが最初にpartialLineに代入される');
                 partialLine = line;
-                console.log(partialLine);
-                console.log('欠損データが最初にpartialLineに代入される');
               } else {
-                console.log('if文の中のpartialLine1');
-                console.log(partialLine);
-                console.log('if文の中のpartialLine1');
                 // この条件分岐に当てはまる場合は partialLine に続きのJSON文字列を結合する
                 partialLine = partialLine + line;
-                console.log('if文の中のpartialLine2');
-                console.log(partialLine);
-                console.log('if文の中のpartialLine2');
               }
-
-              console.log('partialLine');
-              console.log(partialLine);
-              console.log('partialLine');
 
               // partialLine が完全なJSON文字列の場合はParseを実行する
               if (
@@ -158,7 +141,6 @@ export const ChatContent = ({
                 } catch {
                   return null;
                 } finally {
-                  console.log('partialLineのリセットが呼ばれていないかテスト1');
                   partialLine = '';
                 }
               }
@@ -179,8 +161,6 @@ export const ChatContent = ({
                 } catch {
                   return null;
                 } finally {
-                  console.log('partialLineのリセットが呼ばれていないかテスト2');
-
                   partialLine = '';
                 }
               }

--- a/src/app/chat/_components/ChatContent/ChatContent.tsx
+++ b/src/app/chat/_components/ChatContent/ChatContent.tsx
@@ -117,8 +117,8 @@ export const ChatContent = ({
             .decode(value)
             .split('\n\n')
             .map((line) => {
-              // ここに到達する場合は line は不完全なJSON文字列なので partialLine に代入する
               if (line.startsWith('data:')) {
+                // この条件分岐に当てはまる場合は line はデータの開始位置なので partialLine に代入する
                 partialLine = line;
               } else {
                 // この条件分岐に当てはまる場合は partialLine に続きのJSON文字列を結合する

--- a/src/app/chat/_components/ChatContent/ChatContent.tsx
+++ b/src/app/chat/_components/ChatContent/ChatContent.tsx
@@ -125,6 +125,8 @@ export const ChatContent = ({
                 partialLine = partialLine + line;
               }
 
+              console.log(partialLine);
+
               // partialLine が完全なJSON文字列の場合はParseを実行する
               if (
                 partialLine.startsWith('data:') &&
@@ -145,27 +147,6 @@ export const ChatContent = ({
                 }
               }
 
-              // この条件分岐に当てはまる時は完全なJSON文字列
-              if (
-                line.startsWith('data:') &&
-                line.includes('{') &&
-                line.includes('}')
-              ) {
-                const jsonString = line.trim().split('data: ')[1];
-                try {
-                  const parsedJson = JSON.parse(jsonString) as unknown;
-
-                  return isGenerateCatMessageResponse(parsedJson)
-                    ? parsedJson
-                    : null;
-                } catch {
-                  return null;
-                } finally {
-                  partialLine = '';
-                }
-              }
-
-              // ここには到達しないハズ
               return null;
             })
             .filter(Boolean) as GenerateCatMessageResponse[];

--- a/src/app/chat/_components/ChatContent/ChatContent.tsx
+++ b/src/app/chat/_components/ChatContent/ChatContent.tsx
@@ -121,6 +121,16 @@ export const ChatContent = ({
               console.log(line);
               console.log('LINE');
 
+              // ここに到達する場合は line は不完全なJSON文字列なので partialLine に代入する
+              if (line.startsWith('data:') && !partialLine.includes('}')) {
+                partialLine = line;
+              }
+
+              // この条件分岐に当てはまる場合は partialLine に続きのJSON文字列を結合する
+              if (!line.startsWith('data:')) {
+                partialLine = partialLine + line;
+              }
+
               console.log('partialLine');
               console.log(partialLine);
               console.log('partialLine');
@@ -151,8 +161,7 @@ export const ChatContent = ({
                 line.includes('{') &&
                 line.includes('}')
               ) {
-                partialLine = line;
-                const jsonString = partialLine.trim().split('data: ')[1];
+                const jsonString = line.trim().split('data: ')[1];
                 try {
                   const parsedJson = JSON.parse(jsonString) as unknown;
 
@@ -164,13 +173,6 @@ export const ChatContent = ({
                 } finally {
                   partialLine = '';
                 }
-              }
-
-              // ここに到達する場合は line は不完全なJSON文字列なので partialLine に代入する
-              if (line.startsWith('data:')) {
-                partialLine = line;
-              } else {
-                partialLine += line;
               }
 
               // ここには到達しないハズ

--- a/src/app/chat/_components/ChatContent/ChatContent.tsx
+++ b/src/app/chat/_components/ChatContent/ChatContent.tsx
@@ -122,12 +122,10 @@ export const ChatContent = ({
               console.log('LINE');
 
               // ここに到達する場合は line は不完全なJSON文字列なので partialLine に代入する
-              if (line.startsWith('data:') && !partialLine.includes('}')) {
+              if (line.startsWith('data:')) {
                 partialLine = line;
-              }
-
-              // この条件分岐に当てはまる場合は partialLine に続きのJSON文字列を結合する
-              if (!line.startsWith('data:')) {
+              } else {
+                // この条件分岐に当てはまる場合は partialLine に続きのJSON文字列を結合する
                 partialLine = partialLine + line;
               }
 

--- a/src/app/chat/_components/ChatContent/ChatContent.tsx
+++ b/src/app/chat/_components/ChatContent/ChatContent.tsx
@@ -125,8 +125,6 @@ export const ChatContent = ({
                 partialLine = partialLine + line;
               }
 
-              console.log(partialLine);
-
               // partialLine が完全なJSON文字列の場合はParseを実行する
               if (
                 partialLine.startsWith('data:') &&

--- a/src/app/chat/_components/ChatContent/ChatContent.tsx
+++ b/src/app/chat/_components/ChatContent/ChatContent.tsx
@@ -179,7 +179,6 @@ export const ChatContent = ({
                 } catch {
                   return null;
                 } finally {
-
                   console.log('partialLineのリセットが呼ばれていないかテスト2');
 
                   partialLine = '';

--- a/src/utils/__tests__/sse/mightExtractJsonFromSsePayload.spec.ts
+++ b/src/utils/__tests__/sse/mightExtractJsonFromSsePayload.spec.ts
@@ -1,0 +1,30 @@
+import { mightExtractJsonFromSsePayload } from '@/utils/sse';
+import { describe, expect, it } from 'vitest';
+
+describe('src/utils/sse.ts mightExtractJsonFromSsePayload TestCases', () => {
+  type TestTable = {
+    payload: unknown;
+    expected: string;
+  };
+
+  it.each`
+    payload                           | expected
+    ${'data: {"key": "value"}'}       | ${'{"key": "value"}'}
+    ${'data: invalid'}                | ${''}
+    ${123}                            | ${''}
+    ${'data:{"key": "value"}'}        | ${''}
+    ${'data: {"key": 1}'}             | ${'{"key": 1}'}
+    ${'data: {"key": true}'}          | ${'{"key": true}'}
+    ${'data: {"key": false}'}         | ${'{"key": false}'}
+    ${'data: {"key": null}'}          | ${'{"key": null}'}
+    ${'data: {"key": ["1"]}'}         | ${'{"key": ["1"]}'}
+    ${'data: {"key": {"key1": "1"}}'} | ${'{"key": {"key1": "1"}}'}
+    ${'data: {}'}                     | ${'{}'}
+    ${'data: []'}                     | ${'[]'}
+  `(
+    'should return expected JSON string if payload is valid, else return empty string. payload: $payload',
+    ({ payload, expected }: TestTable) => {
+      expect(mightExtractJsonFromSsePayload(payload)).toStrictEqual(expected);
+    },
+  );
+});

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,2 +1,3 @@
 export { sleep } from './sleep';
 export { ExhaustiveError } from './errors';
+export { mightExtractJsonFromSsePayload } from './sse';

--- a/src/utils/isValidJson.ts
+++ b/src/utils/isValidJson.ts
@@ -1,0 +1,13 @@
+export const isValidJson = (input: unknown): boolean => {
+  if (typeof input !== 'string') {
+    return false;
+  }
+
+  try {
+    const obj = JSON.parse(input) as unknown;
+
+    return typeof obj === 'object' && obj !== null;
+  } catch (error) {
+    return false;
+  }
+};

--- a/src/utils/sse.ts
+++ b/src/utils/sse.ts
@@ -1,0 +1,22 @@
+import { isValidJson } from '@/utils/isValidJson';
+
+export const mightExtractJsonFromSsePayload = (payload: unknown): string => {
+  if (typeof payload !== 'string') {
+    return '';
+  }
+
+  if (!payload.startsWith('data: ')) {
+    return '';
+  }
+
+  const list = payload.trim().split('data: ');
+  if (list.length > 1) {
+    return '';
+  }
+
+  if (isValidJson(list[1])) {
+    return list[1];
+  }
+
+  return '';
+};

--- a/src/utils/sse.ts
+++ b/src/utils/sse.ts
@@ -10,12 +10,11 @@ export const mightExtractJsonFromSsePayload = (payload: unknown): string => {
   }
 
   const list = payload.trim().split('data: ');
-  if (list.length > 1) {
-    return '';
-  }
 
-  if (isValidJson(list[1])) {
-    return list[1];
+  if (list.length <= 2) {
+    if (isValidJson(list[1])) {
+      return list[1];
+    }
   }
 
   return '';


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/ai-cat-frontend/issues/59

# この PR で対応する範囲 / この PR で対応しない範囲

Streamingデータの読み込み中の複数行に分かれてしまうJSONデータへの対応を行う。

# Storybook の URL、 スクリーンショット

なし

# 変更点概要

Streamingデータは以下のように `data: JSONデータ` という形式を想定している。

```
data: {"conversationId": "0a7ce2d7-7b76-451c-ab81-169cc756d246", "message": "こ"}
```

しかし実際には以下のように複数行に分かれてデータが流れてくる事があった、その為、稀にデータが欠落してしまう現象が発生していた。

```
data: {"conversationId": "0a
7ce2d7-7b76-451c-ab81-169cc756d246", "message": "こ"}
```

その為、複数行にわたってJSONデータが分かれてしまう場合でも正常にParseできるように対応。

# レビュアーに重点的にチェックして欲しい点

もう少しシンプルなコードにしたかったが良い書き方が思いつかなかったので、良い書き方があれば知りたい。

# 補足情報

特になし