### PR TITLE
Streamingの途中でエラーが発生した場合、エラーメッセージを表示するように変更

### DIFF
--- a/src/app/chat/_components/ChatContent/ChatContent.tsx
+++ b/src/app/chat/_components/ChatContent/ChatContent.tsx
@@ -8,7 +8,7 @@ import {
   type GenerateCatMessageResponse,
 } from '@/features';
 import { type ChatMessage, type ChatMessages } from '@/features/chat';
-import { mightExtractJsonFromSsePayload } from '@/utils';
+import { isSseErrorPayload, mightExtractJsonFromSsePayload } from '@/utils';
 import {
   useDeferredValue,
   useRef,
@@ -141,6 +141,10 @@ export const ChatContent = ({
                 } finally {
                   partialPayload = '';
                 }
+              }
+
+              if (isSseErrorPayload(partialPayload)) {
+                throw new Error('partialPayload is ErrorPayload');
               }
 
               return null;

--- a/src/app/chat/_components/ChatContent/ChatContent.tsx
+++ b/src/app/chat/_components/ChatContent/ChatContent.tsx
@@ -165,6 +165,10 @@ export const ChatContent = ({
 
         reader.releaseLock();
 
+        if (!newResponseMessage) {
+          throw new Error('streamingMessage is empty');
+        }
+
         const newCatMessage = {
           role: 'cat',
           name: 'もこちゃん',

--- a/src/utils/__tests__/sse/isSseErrorPayload.spec.ts
+++ b/src/utils/__tests__/sse/isSseErrorPayload.spec.ts
@@ -1,0 +1,26 @@
+import { isSseErrorPayload } from '@/utils/sse';
+import { describe, expect, it } from 'vitest';
+
+describe('src/utils/sse.ts isSseErrorPayload TestCases', () => {
+  type TestTable = {
+    payload: unknown;
+    expected: boolean;
+  };
+
+  it.each`
+    payload                                                                                    | expected
+    ${'data: {"type": "INTERNAL_SERVER_ERROR", "title": "an unexpected error has occurred."}'} | ${true}
+    ${'data: invalid'}                                                                         | ${false}
+    ${123}                                                                                     | ${false}
+    ${'data: {"key": "value"}'}                                                                | ${false}
+    ${'data: {"type": "error"}'}                                                               | ${false}
+    ${'data: {"title": "An error occurred"}'}                                                  | ${false}
+    ${'A server error has occurred'}                                                           | ${true}
+    ${'INTERNAL_SERVER_ERROR'}                                                                 | ${true}
+  `(
+    'should return true if payload is an error, else return false. payload: $payload',
+    ({ payload, expected }: TestTable) => {
+      expect(isSseErrorPayload(payload)).toStrictEqual(expected);
+    },
+  );
+});

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,3 @@
 export { sleep } from './sleep';
 export { ExhaustiveError } from './errors';
-export { mightExtractJsonFromSsePayload } from './sse';
+export { mightExtractJsonFromSsePayload, isSseErrorPayload } from './sse';


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/ai-cat-frontend/issues/56

# この PR で対応する範囲 / この PR で対応しない範囲

https://github.com/nekochans/ai-cat-frontend/issues/56 の完了の定義を満たす為の実装は全てこのPRで対応。

# Storybook の URL、 スクリーンショット

## エラーの表示対応を実施

<img width="645" alt="スクリーンショット 2024-04-20 18 45 53" src="https://github.com/nekochans/ai-cat-frontend/assets/11032365/97512cc5-5e96-430b-ac13-6c21d0f36bd3">

# 変更点概要

Streamingの途中でエラーが発生した場合やStreamingメッセージが空だった場合はエラーメッセージを表示するように変更。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

特になし